### PR TITLE
Remove external logging package requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ python = ">=3.7,<4.0"
 acme = ">=2.4.0"
 certbot = ">=2.4.0"
 requests = ">=2.31.0"
-logging = ">=0.4.9"
 dnspython = ">=2.3.0"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
The logging package is now included in standard python and including it causes the issue raised in #5.